### PR TITLE
Ensure the original user in the IMBO url is maintained when resizing

### DIFF
--- a/lib/core/DrPublishApiClient.php
+++ b/lib/core/DrPublishApiClient.php
@@ -645,7 +645,13 @@ class DrPublishApiClient
         $imboClient = self::getImboClient();
 
         if ($imboClient) {
+            $user = $imboUrl->getUser();
+            $originalUser = $imboClient->getUser();
+            if (!empty($user)) {
+                $imboClient->setUser($user);
+            }
             $imboUrl = $imboClient->getImageUrl($imageIdentifier);
+            $imboClient->setUser($originalUser);
             foreach ($transformations as $transformation) {
                 if (strpos($transformation, 'maxSize') === false) {
                     $imboUrl->addTransformation($transformation);


### PR DESCRIPTION
When resizing, a new URL is created with the username from the configuration. This causes problems for VGNett, as IMBO-images may have multiple sources. Hardcoding the user results in 404 for these images.

This change ensures the username from the original URL is kept when we generate the new URL.
